### PR TITLE
Fix export support in GF 2.3+

### DIFF
--- a/class-gf-field-business-hours.php
+++ b/class-gf-field-business-hours.php
@@ -13,8 +13,7 @@ class GF_Field_Business_Hours extends GF_Field {
 
 	public $inputType = 'business_hours';
 
-	public function __construct( array $data = array() ) {
-
+	public function __construct( $data = array() ) {
 		parent::__construct( $data );
 
 		$this->add_hooks();

--- a/gravity-forms-business-hours.php
+++ b/gravity-forms-business-hours.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms Business Hours by GravityView
 Plugin URI: https://gravityview.co
 Description: Add a Business Hours field to your Gravity Forms form. Brought to you by <a href="https://gravityview.co">GravityView</a>, the best plugin for displaying Gravity Forms entries.
-Version: 2.1.1
+Version: 2.1.2
 Author: GravityView
 Author URI: https://gravityview.co
 Text Domain: gravity-forms-business-hours

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gravity Forms Business Hours by GravityView ===
 Tags: gravityview,gravity forms, gravity,gravity form,business, hours, time, field, form
 Requires at least: 3.3
-Tested up to: 4.9.8
+Tested up to: 5.0.2
 Stable tag: trunk
 Contributors: katzwebdesign,katzwebservices,gravityview
 License: GPL 3 or higher
@@ -53,6 +53,10 @@ These filters are available for code writers to modify the output:
 3. The Business Hours button in the Form Editor
 
 == Changelog ==
+
+= 2.1.2 on January 7, 2019 =
+
+* Fixed: Error when exporting forms in Gravity Forms that contain Business Hours fields
 
 = 2.1.1 on November 20, 2018 =
 


### PR DESCRIPTION
The constructor can be called with an object to copy in later versions
of GF. Make sure we're not limiting the $properties to array.

Fixes #9

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/991397300387768/991497811763576)
